### PR TITLE
replace node-zendesk with direct api call, fix #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "multer": "~0.1.8",
     "mustache": "1.0.0",
     "node-remote-config-loader": "git://github.com/ubicall/node-remote-config-loader",
-    "node-zendesk": "^1.1.5",
     "nodemailer": "1.3.0",
     "nopt": "3.0.1",
     "oauth": "0.9.12",

--- a/red/ubicall/plist/utils/zendesk.js
+++ b/red/ubicall/plist/utils/zendesk.js
@@ -1,14 +1,28 @@
-var zendesk = require("node-zendesk");
 var when = require("when");
+var request = require("request");
 var log = require("../../../log");
 var plistUtils = require('../nodes/utils.js')
 
+/**
+ * curl https://{subdomain}.zendesk.com/api/v2/ticket_fields.json -v -u {email_address}/token:{token}
+ **/
 function getTicketFields(zd_cred) {
   return when.promise(function(resolve, reject) {
-    var client = zendesk.createClient(zd_cred);
-    client.ticketfields.list(function(err, statusList, body, responseList, resultList) {
-      if (err) return reject(err);
-      else return resolve(resultList[0].ticket_fields);
+    var options = {
+      url: zd_cred.main + "/ticket_fields.json",
+      method: "GET",
+      auth: {
+        username: zd_cred.username,
+        password: zd_cred.token
+      }
+    };
+    request(options, function(error, response, body) {
+      if (error || response.statusCode !== 200) {
+        return reject(error || response.statusCode);
+      } else {
+        var tktfls = JSON.parse(body);
+        return resolve(tktfls.ticket_fields);
+      }
     });
   });
 }


### PR DESCRIPTION
replace node-zendesk with direct api call, depend on these changes [1](https://github.com/Ubicall/ubicall-oauth/blob/36202ebfa11c15ec1fd73e16f326799f90ae12ad/auth/strategies.js#L37-L40), [2](https://github.com/Ubicall/ubicall-oauth/blob/c4ca4757331c881f9f3405e5fc40284e47ad578e/auth/users.js#L64)
